### PR TITLE
Fix dark mode appearance

### DIFF
--- a/Sources/SpeziContact/Contact Views/ContactView.swift
+++ b/Sources/SpeziContact/Contact Views/ContactView.swift
@@ -141,7 +141,7 @@ public struct ContactView: View {
             Button(action: openMaps) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 10)
-                        .foregroundStyle(Color(uiColor: .secondarySystemBackground))
+                        .foregroundStyle(Color(uiColor: .tertiarySystemFill))
                     HStack(alignment: .top) {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Address", bundle: .module, comment: "Contact Button Title")
@@ -182,7 +182,7 @@ public struct ContactView: View {
         Button(action: contactOption.action) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
-                    .foregroundStyle(Color(uiColor: .secondarySystemBackground))
+                    .foregroundStyle(Color(uiColor: .tertiarySystemFill))
                 VStack(spacing: 8) {
                     contactOption.image
                         .font(.title3)


### PR DESCRIPTION
# Fix dark mode appearance

## :recycle: Current situation & Problem
This PR fixes appearance in dark mode. Due to refactorings to lists in #18, we know have to adapt to different backgrounds (e.g., placed directly into a view, placed into a grouped background view, like a List cell).
This was primarily an issue as we used a background color instead of a fill color (see [tertiarySystemFill](https://developer.apple.com/documentation/uikit/uicolor/3255076-tertiarysystemfill) being recommended for buttons and compare to [secondarySystemBackground](https://developer.apple.com/documentation/uikit/uicolor/3173137-secondarysystembackground) which we previously used).


## :gear: Release Notes 
* Fixes appearance in light background when appearing in Lists.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
