### PR TITLE
Adding coding examples for Contact and ContactOption

### DIFF
--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -21,7 +21,7 @@ import SwiftUI
 ///         Contact(
 ///             name: PersonNameComponents(
 ///                 givenName: "First",
-///                  familyName: "Last"
+///                 familyName: "Last"
 ///             ),
 ///             image: Image(systemName: "figure.wave.circle"),
 ///             title: "Title",
@@ -45,7 +45,29 @@ import SwiftUI
 ///     ]
 /// }
 /// ```
-///
+/// 
+/// Here is an additional example of a view  (`ContactRow`), that takes a single ``Contact`` and displays their
+/// name, image, title, and organization.
+///``` swift
+/// struct ContactRow: View {
+///     let contact: Contact
+///     var body: some View {
+///         VStack(alignment: .leading) {
+///             \\ Accessing different properties of the contact
+///             contact.image
+///                 .resizable()
+///                 .frame(width: 50, height: 50)
+///                 .cornerRadius(25)
+///             Text("\(contact.name.givenName) \(contact.name.familyName)")
+///                 .font(.headline)
+///             Text(contact.title)
+///                 .font(.subheadline)
+///             Text(contact.organization)
+///                 .font(.subheadline)
+///         }
+///     }
+/// }
+/// ```
 public struct Contact {
     let id = UUID()
     /// The name of the individual. Ideally provide at least a first and given name.

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -12,32 +12,38 @@ import SwiftUI
 
 /// Encodes the contact information.
 ///
-/// The following example demonstrates the usage of the `Contact`.
+/// ### Usage
+///
+/// The following example demonstrates the usage of the ``Contact`` in a ``ContactsList``.
 /// ```swift
-/// Contact(
-///     name: PersonNameComponents(
-///           givenName: "First",
-///           familyName: "Last"
-///     ),
-///     image: Image(systemName: "figure.wave.circle"),
-///     title: "Title",
-///     description: "Description",
-///     organization: "Organization",
-///     address: {
-///         let address = CNMutablePostalAddress()
-///         address.country = "USA"
-///         address.state = "CA"
-///         address.postalCode = "94305"
-///         address.city = "City"
-///         address.street = "123 ABC St"
-///         return address
-///     }(),
-///     contactOptions: [
-///         .call("+1 (123) 456-7890"),
-///         .text("+1 (123) 456-7890"),
-///         .email(addresses: ["email@address.com"]),
+/// struct Contacts: View {
+///     let contacts = [
+///         Contact(
+///             name: PersonNameComponents(
+///                 givenName: "First",
+///                  familyName: "Last"
+///             ),
+///             image: Image(systemName: "figure.wave.circle"),
+///             title: "Title",
+///             description: "Description",
+///             organization: "Organization",
+///             address: {
+///                 let address = CNMutablePostalAddress()
+///                 address.country = "USA"
+///                 address.state = "CA"
+///                 address.postalCode = "94305"
+///                 address.city = "City"
+///                 address.street = "123 ABC St"
+///                 return address
+///             }(),
+///             contactOptions: [
+///                 .call("+1 (123) 456-7890"),
+///                 .text("+1 (123) 456-7890"),
+///                 .email(addresses: ["email@address.com"]),
+///             ]
+///         )
 ///     ]
-/// )
+/// }
 /// ```
 ///
 public struct Contact {

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -45,10 +45,10 @@ import SwiftUI
 ///     ]
 /// }
 /// ```
-/// 
+///
 /// Here is an additional example of a view  (`ContactRow`), that takes a single ``Contact`` and displays their
 /// name, image, title, and organization.
-///``` swift
+/// ``` swift
 /// struct ContactRow: View {
 ///     let contact: Contact
 ///     var body: some View {

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -11,6 +11,35 @@ import SwiftUI
 
 
 /// Encodes the contact information.
+///
+/// The following example demonstrates the usage of the `Contact`.
+/// ```swift
+/// Contact(
+///     name: PersonNameComponents(
+///           givenName: "First",
+///           familyName: "Last"
+///     ),
+///     image: Image(systemName: "figure.wave.circle"),
+///     title: "Title",
+///     description: "Description",
+///     organization: "Organization",
+///     address: {
+///         let address = CNMutablePostalAddress()
+///         address.country = "USA"
+///         address.state = "CA"
+///         address.postalCode = "94305"
+///         address.city = "City"
+///         address.street = "123 ABC St"
+///         return address
+///     }(),
+///     contactOptions: [
+///         .call("+1 (123) 456-7890"),
+///         .text("+1 (123) 456-7890"),
+///         .email(addresses: ["email@address.com"]),
+///     ]
+/// )
+/// ```
+///
 public struct Contact {
     let id = UUID()
     /// The name of the individual. Ideally provide at least a first and given name.

--- a/Sources/SpeziContact/Models/ContactOption.swift
+++ b/Sources/SpeziContact/Models/ContactOption.swift
@@ -12,17 +12,42 @@ import SwiftUI
 
 /// Customizable way to get in contact with an individual and usually connected to a ``Contact``.
 ///
-/// The following example demonstrates the usage of the `Contact`.
+/// ### Usage
+///
+/// The following example demonstrates the usage of the ``ContactOption`` within a ``Contact``.
 /// ```swift
-/// ContactOption(
-///     image: Image(systemName: "safari.fill"),
-///     title: "More Info",
-///     action: {
-///         // Action that should be performed on pressing this ContactOption (i.e. opening a link for a website)...
-///     }
+/// Contact(
+///     name: PersonNameComponents(
+///         givenName: "First",
+///         familyName: "Last"
+///     ),
+///     image: Image(systemName: "figure.wave.circle"),
+///     title: "Title",
+///     description: "Description",
+///     organization: "Organization",
+///     address: {
+///         let address = CNMutablePostalAddress()
+///         address.country = "USA"
+///         address.state = "CA"
+///         address.postalCode = "94305"
+///         address.city = "City"
+///         address.street = "123 ABC St"
+///         return address
+///     }(),
+///     contactOptions: [
+///         .call("+1 (123) 456-7890"),
+///         .text("+1 (123) 456-7890"),
+///         .email(addresses: ["email@address.com"]),
+///          ContactOption(
+///             image: Image(systemName: "safari.fill"),
+///             title: "More Info",
+///             action: {
+///                 // Action that should be performed on pressing this ContactOption (i.e. opening a link for a website)...
+///              }
+///         )
+///     ]
 /// )
 /// ```
-///
 public struct ContactOption {
     let id = UUID()
     /// The image representing the ``ContactOption`` in the user interface.

--- a/Sources/SpeziContact/Models/ContactOption.swift
+++ b/Sources/SpeziContact/Models/ContactOption.swift
@@ -11,6 +11,18 @@ import SwiftUI
 
 
 /// Customizable way to get in contact with an individual and usually connected to a ``Contact``.
+///
+/// The following example demonstrates the usage of the `Contact`.
+/// ```swift
+/// ContactOption(
+///     image: Image(systemName: "safari.fill"),
+///     title: "More Info",
+///     action: {
+///         // Action that should be performed on pressing this ContactOption (i.e. opening a link for a website)...
+///     }
+/// )
+/// ```
+///
 public struct ContactOption {
     let id = UUID()
     /// The image representing the ``ContactOption`` in the user interface.

--- a/Sources/SpeziContact/Models/ContactOption.swift
+++ b/Sources/SpeziContact/Models/ContactOption.swift
@@ -14,36 +14,21 @@ import SwiftUI
 ///
 /// ### Usage
 ///
-/// The following example demonstrates the usage of the ``ContactOption`` within a ``Contact``.
+/// The following example demonstrates the usage of the ``ContactOption`` within a ``Contact``. For additional details on the implementation of a ``Contact``, please refer to its page.
 /// ```swift
 /// Contact(
-///     name: PersonNameComponents(
-///         givenName: "First",
-///         familyName: "Last"
-///     ),
-///     image: Image(systemName: "figure.wave.circle"),
-///     title: "Title",
-///     description: "Description",
-///     organization: "Organization",
-///     address: {
-///         let address = CNMutablePostalAddress()
-///         address.country = "USA"
-///         address.state = "CA"
-///         address.postalCode = "94305"
-///         address.city = "City"
-///         address.street = "123 ABC St"
-///         return address
-///     }(),
+///     // other parameters for Contact
 ///     contactOptions: [
 ///         .call("+1 (123) 456-7890"),
 ///         .text("+1 (123) 456-7890"),
 ///         .email(addresses: ["email@address.com"]),
-///          ContactOption(
-///             image: Image(systemName: "safari.fill"),
-///             title: "More Info",
-///             action: {
-///                 // Action that should be performed on pressing this ContactOption (i.e. opening a link for a website)...
-///              }
+///         // Here is where the custom ContactOption can be used as a part of the contactOptions list
+///         ContactOption(
+///            image: Image(systemName: "safari.fill"),
+///            title: "More Info",
+///            action: {
+///                // Action that should be performed on pressing this ContactOption (i.e. opening a link for a website)...
+///             }
 ///         )
 ///     ]
 /// )


### PR DESCRIPTION
# *Adding coding examples for Contact and ContactOption*

## :recycle: Current situation & Problem
When I was creating a contact for our application, I was unable to see coding examples. These added examples hope to clarify how someone might build and implement these features.


## :books: Documentation
- Improve documentation by showing an example of hot to build new Contact as well as custom ContactOptions


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
