### PR TITLE
Adding coding examples for Contact and ContactOption - v2 with signed commits

### DIFF
--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// ### Usage
 ///
 /// The following example demonstrates the initialization of a ``Contact`` and an example view
-/// that displays its corresopnding name, image, title, and organization.
+/// that displays its corresponding ``Contact`` name, image, title, and organization.
 /// ```swift
 /// struct ContactRow: View {
 ///     let contact =
@@ -46,7 +46,7 @@ import SwiftUI
 ///
 ///     var body: some View {
 ///         VStack(alignment: .leading) {
-///             \\ Accessing different properties of the contact
+///             // Accessing different properties of the contact
 ///             contact.image
 ///                 .resizable()
 ///                 .frame(width: 50, height: 50)

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -11,6 +11,63 @@ import SwiftUI
 
 
 /// Encodes the contact information.
+///
+/// ### Usage
+///
+/// The following example demonstrates the usage of the ``Contact`` in a ``ContactsList``.
+/// ```swift
+/// struct Contacts: View {
+///     let contacts = [
+///         Contact(
+///             name: PersonNameComponents(
+///                 givenName: "First",
+///                 familyName: "Last"
+///             ),
+///             image: Image(systemName: "figure.wave.circle"),
+///             title: "Title",
+///             description: "Description",
+///             organization: "Organization",
+///             address: {
+///                 let address = CNMutablePostalAddress()
+///                 address.country = "USA"
+///                 address.state = "CA"
+///                 address.postalCode = "94305"
+///                 address.city = "City"
+///                 address.street = "123 ABC St"
+///                 return address
+///             }(),
+///             contactOptions: [
+///                 .call("+1 (123) 456-7890"),
+///                 .text("+1 (123) 456-7890"),
+///                 .email(addresses: ["email@address.com"]),
+///             ]
+///         )
+///     ]
+/// }
+/// ```
+///
+/// Here is an additional example of a view  (`ContactRow`), that takes a single ``Contact`` and displays their
+/// name, image, title, and organization.
+/// ``` swift
+/// struct ContactRow: View {
+///     let contact: Contact
+///     var body: some View {
+///         VStack(alignment: .leading) {
+///             \\ Accessing different properties of the contact
+///             contact.image
+///                 .resizable()
+///                 .frame(width: 50, height: 50)
+///                 .cornerRadius(25)
+///             Text("\(contact.name.givenName) \(contact.name.familyName)")
+///                 .font(.headline)
+///             Text(contact.title)
+///                 .font(.subheadline)
+///             Text(contact.organization)
+///                 .font(.subheadline)
+///         }
+///     }
+/// }
+/// ```
 public struct Contact {
     let id = UUID()
     /// The name of the individual. Ideally provide at least a first and given name.

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -14,7 +14,8 @@ import SwiftUI
 ///
 /// ### Usage
 ///
-/// The following example demonstrates the usage of the ``Contact`` in a ``ContactsList``.
+/// The following examples demonstrates the usage of the ``Contact`` in a ``ContactsList`` (`Contacts`) and an example view
+/// (`ContactRow`), that takes a single ``Contact`` and displays the corresopnding name, image, title, and organization.
 /// ```swift
 /// struct Contacts: View {
 ///     let contacts = [
@@ -44,11 +45,7 @@ import SwiftUI
 ///         )
 ///     ]
 /// }
-/// ```
 ///
-/// Here is an additional example of a view  (`ContactRow`), that takes a single ``Contact`` and displays their
-/// name, image, title, and organization.
-/// ``` swift
 /// struct ContactRow: View {
 ///     let contact: Contact
 ///     var body: some View {

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -14,11 +14,11 @@ import SwiftUI
 ///
 /// ### Usage
 ///
-/// The following examples demonstrates the usage of the ``Contact`` in a ``ContactsList`` (`Contacts`) and an example view
-/// (`ContactRow`), that takes a single ``Contact`` and displays the corresopnding name, image, title, and organization.
+/// The following example demonstrates the initialization of a ``Contact`` and an example view
+/// that displays its corresopnding name, image, title, and organization.
 /// ```swift
-/// struct Contacts: View {
-///     let contacts = [
+/// struct ContactRow: View {
+///     let contact =
 ///         Contact(
 ///             name: PersonNameComponents(
 ///                 givenName: "First",
@@ -43,11 +43,7 @@ import SwiftUI
 ///                 .email(addresses: ["email@address.com"]),
 ///             ]
 ///         )
-///     ]
-/// }
 ///
-/// struct ContactRow: View {
-///     let contact: Contact
 ///     var body: some View {
 ///         VStack(alignment: .leading) {
 ///             \\ Accessing different properties of the contact

--- a/Sources/SpeziContact/Models/ContactOption.swift
+++ b/Sources/SpeziContact/Models/ContactOption.swift
@@ -14,7 +14,7 @@ import SwiftUI
 ///
 /// ### Usage
 ///
-/// The following example demonstrates the usage of the ``ContactOption`` within a ``Contact``. For additional details on the implementation of a ``Contact``, please refer to its page.
+/// The following example demonstrates the usage of the ``ContactOption`` within a ``Contact``. For additional details, refer to the ``Contact`` documentation.
 /// ```swift
 /// Contact(
 ///     // other parameters for Contact

--- a/Sources/SpeziContact/Models/ContactOption.swift
+++ b/Sources/SpeziContact/Models/ContactOption.swift
@@ -11,6 +11,28 @@ import SwiftUI
 
 
 /// Customizable way to get in contact with an individual and usually connected to a ``Contact``.
+///
+/// ### Usage
+///
+/// The following example demonstrates the usage of the ``ContactOption`` within a ``Contact``. For additional details on the implementation of a ``Contact``, please refer to its page.
+/// ```swift
+/// Contact(
+///     // other parameters for Contact
+///     contactOptions: [
+///         .call("+1 (123) 456-7890"),
+///         .text("+1 (123) 456-7890"),
+///         .email(addresses: ["email@address.com"]),
+///         // Here is where the custom ContactOption can be used as a part of the contactOptions list
+///         ContactOption(
+///            image: Image(systemName: "safari.fill"),
+///            title: "More Info",
+///            action: {
+///                // Action that should be performed on pressing this ContactOption (i.e. opening a link for a website)...
+///             }
+///         )
+///     ]
+/// )
+/// ```
 public struct ContactOption {
     let id = UUID()
     /// The image representing the ``ContactOption`` in the user interface.


### PR DESCRIPTION
# *Adding coding examples for Contact and ContactOption - v2 with signed commits*

## :recycle: Current situation & Problem
When I was creating a contact for our application, I was unable to see coding examples. These added examples hope to clarify how someone might build and implement these features.

**All of these changes were copied over from my previous pull request for signed commits.**


## :gear: Release Notes 
N/A


## :books: Documentation
- Improve documentation by showing an example of how to build new Contact as well as custom ContactOptions embedded within larger body of code


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
