### PR TITLE
Fix export of CNPostalAddress

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ func swiftLintPlugin() -> [Target.PluginUsage] {
 
 func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
     if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.1"))]
+        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
     } else {
         []
     }

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@preconcurrency @_exported import class Contacts.CNPostalAddress
+@_exported import class Contacts.CNPostalAddress
 import SwiftUI
 
 

--- a/Sources/SpeziContact/Models/Contact.swift
+++ b/Sources/SpeziContact/Models/Contact.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_exported import class Contacts.CNPostalAddress
+@_exported import Contacts.CNPostalAddress
 import SwiftUI
 
 

--- a/Tests/UITests/TestApp/ContactsTestsView.swift
+++ b/Tests/UITests/TestApp/ContactsTestsView.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Contacts
 import SpeziContact
 import SwiftUI
 


### PR DESCRIPTION
# Fix export of CNPostalAddress

## :recycle: Current situation & Problem
This issue resolve the `@_exported` import that was prevented due to the `@preconcurrency` annotation.


## :gear: Release Notes 
* Fixed an issue for users relying on SpeziContacts to import the `Contacts` framework.


## :books: Documentation
--


## :white_check_mark: Testing
Tests were updated to remove the import.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
